### PR TITLE
Make backtrace support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 
 option(BUILD_TESTING "Run unit tests" OFF)
+option(BUILD_BACKTRACE_SUPPORT "Build with backtrace support from libbacktrace" OFF)
 
 # configure clang-tidy if requested
 option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,8 +21,15 @@ target_link_libraries(log
         Boost::filesystem
         Boost::log_setup
         Boost::log
+)
+
+if (BUILD_BACKTRACE_SUPPORT)
+target_link_libraries(log
+    PRIVATE
         backtrace
 )
+target_compile_definitions(log PRIVATE WITH_LIBBACKTRACE)
+endif()
 
 # needs c++ 14
 target_compile_features(log PUBLIC cxx_std_14)

--- a/lib/trace.cpp
+++ b/lib/trace.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <everest/logging.hpp>
 
+#ifdef WITH_LIBBACKTRACE
 #include <backtrace-supported.h>
 #include <backtrace.h>
 #include <cxxabi.h>
@@ -49,9 +50,12 @@ inline int frame_handler(void* data, uintptr_t pc, const char* filename, int lin
     return 0; // continue backtracing
 }
 
+#endif
+
 namespace Everest {
 namespace Logging {
 std::string trace() {
+#ifdef WITH_LIBBACKTRACE
     {
         std::lock_guard<std::mutex> lck(init_mtx);
         if (!tried_to_initialize) {
@@ -64,7 +68,7 @@ std::string trace() {
     if (bt_state == nullptr) {
         return "Backtrace functionality not available\n";
     }
-    
+
     StackTrace trace;
 
     // FIXME (aw): 1 means we're skipping this functions frame, can this
@@ -73,6 +77,9 @@ std::string trace() {
     backtrace_full(bt_state, 1, frame_handler, nullptr, &trace);
 
     return trace.info;
+#else
+    return "Backtrace functionality not built in\n";
+#endif
 }
 } // namespace Logging
 } // namespace Everest


### PR DESCRIPTION
- unfortunately, libbacktrace doesn't seem to exists on OpenSUSE,
  therefor it is made optional for now (CMake support for libbacktrace
  will be added later)

Signed-off-by: aw <aw@pionix.de>