### PR TITLE
Fix build in ninja by specifying libbacktrace.a as a build byproduct.

### DIFF
--- a/3rd_party/libbacktrace/CMakeLists.txt
+++ b/3rd_party/libbacktrace/CMakeLists.txt
@@ -15,6 +15,8 @@ ExternalProject_Add(
 # make
     BUILD_COMMAND ${MAKE}
     BUILD_ALWAYS false
+# specify byproducts
+    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/lib/libbacktrace.a
 # log options
     LOG_DOWNLOAD true
     LOG_CONFIGURE true


### PR DESCRIPTION
Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>