### PR TITLE
Disable shallow clone for libbacktrace dependency

### DIFF
--- a/3rd_party/libbacktrace/CMakeLists.txt
+++ b/3rd_party/libbacktrace/CMakeLists.txt
@@ -7,7 +7,7 @@ ExternalProject_Add(
 # download
     GIT_REPOSITORY https://github.com/ianlancetaylor/libbacktrace
     GIT_TAG 2446c66076480ce07a6bd868badcbceb3eeecc2e
-    GIT_SHALLOW true
+    GIT_SHALLOW false
 # update
     UPDATE_COMMAND ""
 # configure

--- a/3rd_party/libbacktrace/CMakeLists.txt
+++ b/3rd_party/libbacktrace/CMakeLists.txt
@@ -6,7 +6,7 @@ ExternalProject_Add(
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}
 # download
     GIT_REPOSITORY https://github.com/ianlancetaylor/libbacktrace
-    GIT_TAG 2446c66076480ce07a6bd868badcbceb3eeecc2e
+    GIT_TAG 4d2dd0b172f2c9192f83ba93425f868f2a13c553
     GIT_SHALLOW false
 # update
     UPDATE_COMMAND ""


### PR DESCRIPTION
Shallow cloning breaks whenever GIT_TAG is not the current HEAD.

Also update GIT_TAG to revision of current HEAD