### PR TITLE
Add optional log callback to init function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
 
 
 # library dependencies
-find_package(Boost COMPONENTS log_setup log filesystem REQUIRED)
+find_package(Boost COMPONENTS log_setup log REQUIRED)
 
 
 # third party dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(everest-log
-    VERSION 0.1
+    VERSION 0.2
     DESCRIPTION "EVerest logging library"
     LANGUAGES CXX C
 )

--- a/examples/logging.ini
+++ b/examples/logging.ini
@@ -3,7 +3,7 @@
 
 [Core]
 DisableLogging=false
-Filter="%Severity% >= DEBUG"
+Filter="%Severity% >= DEBG"
 
 [Sinks.Console]
 Destination=Console

--- a/examples/logging.ini
+++ b/examples/logging.ini
@@ -3,7 +3,7 @@
 
 [Core]
 DisableLogging=false
-Filter="%Severity% >= DEBG"
+Filter="%Severity% >= VERB"
 
 [Sinks.Console]
 Destination=Console

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -46,6 +46,12 @@ int main(int argc, char* argv[]) {
             if (record.function.has_value()) {
                 std::cout << "Function: " << *record.function << std::endl;
             }
+            if (record.line.has_value()) {
+                std::cout << "Line: " << *record.line << std::endl;
+            }
+            if (record.file.has_value()) {
+                std::cout << "File: " << *record.file << std::endl;
+            }
         });
     } else {
         Everest::Logging::init(logging_config, "hello there");

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -13,6 +13,7 @@ int main(int argc, char* argv[]) {
     po::options_description desc("EVerest::log example");
     desc.add_options()("help,h", "produce help message");
     desc.add_options()("logconf", po::value<std::string>(), "The path to a custom logging.ini");
+    desc.add_options()("callback,c", "Use example log callback");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -28,7 +29,27 @@ int main(int argc, char* argv[]) {
     if (vm.count("logconf") != 0) {
         logging_config = vm["logconf"].as<std::string>();
     }
-    Everest::Logging::init(logging_config, "hello there");
+
+    if (vm.count("callback") != 0) {
+        std::cout << "Using log callback" << std::endl;
+        Everest::Logging::init(logging_config, "hello there", [](const Everest::Logging::LogRecord& record) {
+            std::cout << "Message: " << record.message << std::endl;
+            if (record.severity.has_value()) {
+                std::cout << "Severity: " << *record.severity << std::endl;
+            }
+            if (record.timestamp.has_value()) {
+                std::cout << "TimeStamp: " << *record.timestamp << std::endl;
+            }
+            if (record.process.has_value()) {
+                std::cout << "Process: " << *record.process << std::endl;
+            }
+            if (record.function.has_value()) {
+                std::cout << "Function: " << *record.function << std::endl;
+            }
+        });
+    } else {
+        Everest::Logging::init(logging_config, "hello there");
+    }
 
     EVLOG_debug << "logging_config was set to " << logging_config;
 

--- a/include/everest/logging.hpp
+++ b/include/everest/logging.hpp
@@ -17,6 +17,9 @@
 #include <optional>
 #include <string>
 
+namespace logging = boost::log::BOOST_LOG_VERSION_NAMESPACE;
+namespace attrs = logging::attributes;
+
 namespace Everest {
 namespace Logging {
 
@@ -35,6 +38,8 @@ struct LogRecord {
     std::optional<std::string> timestamp;
     std::optional<std::string> process;
     std::optional<std::string> function;
+    std::optional<int> line;
+    std::optional<std::string> file;
 };
 
 void init(const std::string& logconf);
@@ -47,37 +52,51 @@ std::string trace();
 } // namespace Logging
 
 // clang-format off
+#define LOG_METADATA                                                                                                   \
+  logging::attribute_cast<attrs::mutable_constant<std::string>>(                                                       \
+    logging::core::get()->get_global_attributes()["Function"]).set(BOOST_CURRENT_FUNCTION);                            \
+  logging::attribute_cast<attrs::mutable_constant<int>>(                                                               \
+    logging::core::get()->get_global_attributes()["Line"]).set(__LINE__);                                              \
+  logging::attribute_cast<attrs::mutable_constant<std::string>>(                                                       \
+    logging::core::get()->get_global_attributes()["File"]).set(__FILE__);
+
 #define EVLOG_verbose                                                                                                  \
+    LOG_METADATA;                                                                                                      \
     BOOST_LOG_SEV(::global_logger::get(), ::Everest::Logging::verbose)                                                 \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("file", __FILE__)                                        \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("line", __LINE__)                                        \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("function", BOOST_CURRENT_FUNCTION)
+        << logging::add_value("file", __FILE__)                                                                        \
+        << logging::add_value("line", __LINE__)                                                                        \
+        << logging::add_value("function", BOOST_CURRENT_FUNCTION)
 
 #define EVLOG_debug                                                                                                    \
+    LOG_METADATA;                                                                                                      \
     BOOST_LOG_SEV(::global_logger::get(), ::Everest::Logging::debug)                                                   \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("function", BOOST_CURRENT_FUNCTION)
+        << logging::add_value("function", BOOST_CURRENT_FUNCTION)
 
 #define EVLOG_info                                                                                                     \
+    LOG_METADATA;                                                                                                      \
     BOOST_LOG_SEV(::global_logger::get(), ::Everest::Logging::info)
 
 #define EVLOG_warning                                                                                                  \
+    LOG_METADATA;                                                                                                      \
     BOOST_LOG_SEV(::global_logger::get(), ::Everest::Logging::warning)                                                 \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("function", BOOST_CURRENT_FUNCTION)
+        << logging::add_value("function", BOOST_CURRENT_FUNCTION)
 
 #define EVLOG_error                                                                                                    \
+    LOG_METADATA;                                                                                                      \
     BOOST_LOG_SEV(::global_logger::get(), ::Everest::Logging::error)                                                   \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("function", BOOST_CURRENT_FUNCTION)
+        << logging::add_value("function", BOOST_CURRENT_FUNCTION)
 
 #define EVLOG_critical                                                                                                 \
+    LOG_METADATA;                                                                                                      \
     BOOST_LOG_SEV(::global_logger::get(), ::Everest::Logging::critical)                                                \
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("function", BOOST_CURRENT_FUNCTION)
+        << logging::add_value("function", BOOST_CURRENT_FUNCTION)
 // clang-format on
 
 #define EVLOG_AND_THROW(ex)                                                                                            \
     do {                                                                                                               \
         try {                                                                                                          \
             BOOST_THROW_EXCEPTION(boost::enable_error_info(ex)                                                         \
-                                  << boost::log::BOOST_LOG_VERSION_NAMESPACE::current_scope());                        \
+                                  << logging::current_scope());                                                        \
         } catch (std::exception & e) {                                                                                 \
             EVLOG_error << e.what();                                                                                   \
             throw;                                                                                                     \
@@ -87,12 +106,12 @@ std::string trace();
 #define EVTHROW(ex)                                                                                                    \
     do {                                                                                                               \
         BOOST_THROW_EXCEPTION(boost::enable_error_info(ex)                                                             \
-                              << boost::log::BOOST_LOG_VERSION_NAMESPACE::current_scope());                            \
+                              << logging::current_scope());                                                            \
     } while (0)
 } // namespace Everest
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
     global_logger,
-    boost::log::BOOST_LOG_VERSION_NAMESPACE::sources::severity_logger_mt<Everest::Logging::severity_level>)
+    logging::sources::severity_logger_mt<Everest::Logging::severity_level>)
 
 #endif // LOGGING_HPP

--- a/include/everest/logging.hpp
+++ b/include/everest/logging.hpp
@@ -14,6 +14,7 @@
 #include <boost/log/utility/manipulators/add_value.hpp>
 #include <boost/throw_exception.hpp>
 #include <exception>
+#include <optional>
 #include <string>
 
 namespace Everest {
@@ -28,8 +29,19 @@ enum severity_level {
     critical,
 };
 
+struct LogRecord {
+    std::string message;
+    std::optional<severity_level> severity;
+    std::optional<std::string> timestamp;
+    std::optional<std::string> process;
+    std::optional<std::string> function;
+};
+
 void init(const std::string& logconf);
+void init(const std::string& logconf, const std::function<void(const LogRecord& record)>& log_callback);
 void init(const std::string& logconf, std::string process_name);
+void init(const std::string& logconf, std::string process_name,
+          const std::function<void(const LogRecord& record)>& log_callback);
 void update_process_name(std::string process_name);
 std::string trace();
 } // namespace Logging

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(log
         Boost::log_setup
 )
 
+# we need support for C++17 for std:optional
+target_compile_features(log PUBLIC cxx_std_17)
+
 # FIXME (aw): in case FindBoost.cmake was used we need to add things
 #             this should be removed no support for Boost < 1.74 is needed
 if (NOT Boost_DIR)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,7 +17,6 @@ target_link_libraries(log
     PUBLIC
         Boost::log
     PRIVATE
-        Boost::filesystem
         Boost::log_setup
 )
 

--- a/lib/logging.cpp
+++ b/lib/logging.cpp
@@ -27,9 +27,6 @@
         throw(exception);                                                                                              \
     } while (0);
 
-namespace logging = boost::log::BOOST_LOG_VERSION_NAMESPACE;
-namespace attrs = logging::attributes;
-
 namespace Everest {
 namespace Logging {
 std::array<std::string, 6> severity_strings = {
@@ -121,11 +118,15 @@ public:
         if (logging::value_ref<std::string> process = rec["Process"].extract<std::string>()) {
             log_record.process = *process;
         }
-        if (logging::value_ref<std::string> function = rec["function"].extract<std::string>()) {
+        if (logging::value_ref<std::string> function = rec["Function"].extract<std::string>()) {
             log_record.function = *function;
-
         }
-
+        if (logging::value_ref<int> line = rec["Line"].extract<int>()) {
+            log_record.line = *line;
+        }
+        if (logging::value_ref<std::string> file = rec["File"].extract<std::string>()) {
+            log_record.file = *file;
+        }
         log_callback(log_record);
     }
 
@@ -137,8 +138,7 @@ void init(const std::string& logconf) {
     init(logconf, "");
 }
 
-void init(const std::string& logconf,
-          const std::function<void(const LogRecord& record)>& log_callback) {
+void init(const std::string& logconf, const std::function<void(const LogRecord& record)>& log_callback) {
     init(logconf, "", log_callback);
 }
 
@@ -164,6 +164,9 @@ void init(const std::string& logconf, std::string process_name,
         current_process_name.set(padded_process_name);
     }
     logging::core::get()->add_global_attribute("Scope", attrs::named_scope());
+    logging::core::get()->add_global_attribute("Function", attrs::mutable_constant<std::string>(""));
+    logging::core::get()->add_global_attribute("Line", attrs::mutable_constant<int>(0));
+    logging::core::get()->add_global_attribute("File", attrs::mutable_constant<std::string>(""));
 
     // register callback sink if a log callback was provided
     if (log_callback != nullptr) {

--- a/lib/logging.cpp
+++ b/lib/logging.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
 #include <boost/date_time/posix_time/time_formatters_limited.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/log/attributes/current_process_id.hpp>
 #include <boost/log/attributes/current_process_name.hpp>
 #include <boost/log/attributes/current_thread_id.hpp>
@@ -15,6 +14,7 @@
 #include <boost/log/utility/setup/settings.hpp>
 #include <boost/log/utility/setup/settings_parser.hpp>
 #include <fstream>
+#include <filesystem>
 
 #include <everest/exceptions.hpp>
 #include <everest/logging.hpp>
@@ -27,7 +27,6 @@
         throw(exception);                                                                                              \
     } while (0);
 
-namespace fs = boost::filesystem;
 namespace logging = boost::log::BOOST_LOG_VERSION_NAMESPACE;
 namespace attrs = logging::attributes;
 
@@ -178,11 +177,11 @@ void init(const std::string& logconf, std::string process_name,
 
     // open logging.ini config file located at our base_dir and use it to configure boost::log logging (filters and
     // format)
-    fs::path logging_path = fs::path(logconf);
+    std::filesystem::path logging_path = std::filesystem::path(logconf);
     std::ifstream logging_config(logging_path.c_str());
     if (!logging_config.is_open()) {
         EVEREST_INTERNAL_LOG_AND_THROW(EverestConfigError(std::string("Could not open logging config file at ") +
-                                                          std::string(fs::absolute(logging_path).c_str())));
+                                                          std::string(std::filesystem::absolute(logging_path).c_str())));
     }
 
     auto settings = logging::parse_settings(logging_config);

--- a/lib/logging.cpp
+++ b/lib/logging.cpp
@@ -98,7 +98,7 @@ public:
         sink(cross_thread), log_callback(log_callback) {
     }
 
-    bool will_consume(logging::attribute_value_set const& attributes) {
+    bool will_consume([[maybe_unused]] logging::attribute_value_set const& attributes) {
         return true;
     }
 


### PR DESCRIPTION
Here a allback function can be registered that receives a LogRecord, containing the message, severity, timestamp, process and function (if available respectively)