### PR TITLE
Use std::filesystem by default but allow fallback to boost:filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(everest-log
-    VERSION 0.1
+    VERSION 0.2
     DESCRIPTION "EVerest logging library"
     LANGUAGES CXX C
 )
@@ -16,10 +16,16 @@ option(BUILD_TESTING "Run unit tests" OFF)
 option(BUILD_EXAMPLES "Build liblog example binaries." OFF)
 option(LOG_INSTALL "Install the library (shared data might be installed anyway)" ${EVC_MAIN_PROJECT})
 option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
-
+option(LIBLOG_USE_BOOST_FILESYSTEM "Usage of boost/filesystem.hpp instead of std::filesystem" OFF)
 
 # library dependencies
-find_package(Boost COMPONENTS log_setup log filesystem REQUIRED)
+
+if (LIBLOG_USE_BOOST_FILESYSTEM) 
+    message(STATUS "Using boost/filesystem instead of std::filesystem")
+    find_package(Boost COMPONENTS log_setup log filesystem REQUIRED)
+else()
+    find_package(Boost COMPONENTS log_setup log REQUIRED)
+endif()
 
 
 # third party dependencies

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,9 +17,19 @@ target_link_libraries(log
     PUBLIC
         Boost::log
     PRIVATE
-        Boost::filesystem
         Boost::log_setup
 )
+
+if (LIBLOG_USE_BOOST_FILESYSTEM)
+    target_link_libraries(log
+        PRIVATE
+            Boost::filesystem
+    )
+    target_compile_definitions(log
+        PRIVATE
+            LIBLOG_USE_BOOST_FILESYSTEM
+    )
+endif()
 
 # FIXME (aw): in case FindBoost.cmake was used we need to add things
 #             this should be removed no support for Boost < 1.74 is needed

--- a/lib/logging.cpp
+++ b/lib/logging.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+#ifdef LIBLOG_USE_BOOST_FILESYSTEM
 #include <boost/filesystem.hpp>
+#else
+#include <filesystem>
+#endif
 #include <boost/log/attributes/current_process_id.hpp>
 #include <boost/log/attributes/current_process_name.hpp>
 #include <boost/log/attributes/current_thread_id.hpp>
@@ -26,7 +30,11 @@
         throw(exception);                                                                                              \
     } while (0);
 
+#ifdef LIBLOG_USE_BOOST_FILESYSTEM
 namespace fs = boost::filesystem;
+#else
+namespace fs = std::filesystem;
+#endif
 namespace logging = boost::log::BOOST_LOG_VERSION_NAMESPACE;
 namespace attrs = logging::attributes;
 


### PR DESCRIPTION
If you set LIBLOG_USE_BOOST_FILESYSTEM to "ON" liblog can still use boost::filesystem